### PR TITLE
I need logs in public space

### DIFF
--- a/app_src/main.py
+++ b/app_src/main.py
@@ -167,7 +167,7 @@ class WallpaperCarouselApp(MDApp):
                         # Fix for permission Error when choosing from Internal Storage section Android FileExplorer
                         self.file_operation.intent = intent
                 except Exception as error_getting_path:
-                    app_logger.exception("error_getting_path", error_getting_path)
+                    app_logger.exception(f"error_getting_path: {error_getting_path}")
 
             activity.bind(
                 on_activity_result=set_intent_for_file_operation_class)

--- a/app_src/main.py
+++ b/app_src/main.py
@@ -1,3 +1,6 @@
+from utils.helper import write_logs_to_file
+write_logs_to_file()
+
 import logging
 import traceback
 

--- a/app_src/main.py
+++ b/app_src/main.py
@@ -1,59 +1,5 @@
 from utils.helper import write_logs_to_file
 write_logs_to_file()
-import materialyoucolor
-from android_notify import Notification
-m=f"materialyoucolor: {materialyoucolor.__version__}"
-print(m)
-Notification(
-    title="Version",
-    message=m).send()
-
-
-
-
-
-
-
-
-
-import os
-from jnius import autoclass
-from android_notify import Notification
-
-PythonActivity = autoclass("org.kivy.android.PythonActivity")
-context = PythonActivity.mActivity
-
-base = context.getFilesDir().getAbsolutePath()
-
-matches = []
-
-for root, dirs, files in os.walk(base):
-    if "materialyoucolor" in root:
-        matches.append(f"\n{root}")
-        for d in sorted(dirs):
-            matches.append(f"  📁 {d}")
-        for f in sorted(files):
-            matches.append(f"  📄 {f}")
-
-text = "\n".join(matches) if matches else "materialyoucolor not found"
-print(text)
-n=Notification(
-    title="materialyoucolor Files",
-    message="Tap to expand"
-)
-n.setBigText(text[:4000])
-n.send()
-
-
-
-
-
-
-
-
-
-
-
 
 import logging
 import traceback

--- a/app_src/main.py
+++ b/app_src/main.py
@@ -1,5 +1,12 @@
 from utils.helper import write_logs_to_file
 write_logs_to_file()
+import materialyoucolor
+from android_notify import Notification
+m=f"materialyoucolor: {materialyoucolor.__version__}"
+print(m)
+Notification(
+    title="Version",
+    message=m).send()
 
 import logging
 import traceback

--- a/app_src/main.py
+++ b/app_src/main.py
@@ -8,6 +8,53 @@ Notification(
     title="Version",
     message=m).send()
 
+
+
+
+
+
+
+
+
+import os
+from jnius import autoclass
+from android_notify import Notification
+
+PythonActivity = autoclass("org.kivy.android.PythonActivity")
+context = PythonActivity.mActivity
+
+base = context.getFilesDir().getAbsolutePath()
+
+matches = []
+
+for root, dirs, files in os.walk(base):
+    if "materialyoucolor" in root:
+        matches.append(f"\n{root}")
+        for d in sorted(dirs):
+            matches.append(f"  📁 {d}")
+        for f in sorted(files):
+            matches.append(f"  📄 {f}")
+
+text = "\n".join(matches) if matches else "materialyoucolor not found"
+print(text)
+n=Notification(
+    title="materialyoucolor Files",
+    message="Tap to expand"
+)
+n.setBigText(text[:4000])
+n.send()
+
+
+
+
+
+
+
+
+
+
+
+
 import logging
 import traceback
 

--- a/app_src/utils/helper.py
+++ b/app_src/utils/helper.py
@@ -89,12 +89,21 @@ class Tee:
             Log.d("python", message)
 
 
+
+
+def app_external_storage_path():
+    PythonActivity = autoclass("org.kivy.android.PythonActivity")
+    context = PythonActivity.mActivity
+
+    ext_dir = context.getExternalFilesDir(None)
+    return ext_dir.getAbsolutePath() if ext_dir else appFolder()
+	
 def write_logs_to_file(log_folder_name="logs", file_name="all_output1.txt"):
     if DEV or not on_android_platform():
         return
     try:
 
-        log_folder = os.path.join(appFolder(), log_folder_name)
+        log_folder = os.path.join(app_external_storage_path(), log_folder_name)
         makeFolder(log_folder)
 
         # Log file path

--- a/app_src/utils/helper.py
+++ b/app_src/utils/helper.py
@@ -92,8 +92,7 @@ class Tee:
 
 
 def app_external_storage_path():
-    PythonActivity = autoclass("org.kivy.android.PythonActivity")
-    context = PythonActivity.mActivity
+    context = get_python_activity_context()
 
     ext_dir = context.getExternalFilesDir(None)
     return ext_dir.getAbsolutePath() if ext_dir else appFolder()

--- a/buildozer.spec
+++ b/buildozer.spec
@@ -21,7 +21,7 @@ source.include_exts = py,png,jpg,kv,atlas,ttf,json,xml,wav
 source.exclude_dirs = bin, venv,lab, worked, __pycache__, .idea, dist, for-download,laner-linux, .filereader, wallpapers
 
 
-requirements = python3,kivy,https://github.com/kivymd/KivyMD/archive/master.zip,python-osc,https://github.com/kivy/plyer/archive/master.zip,materialyoucolor==3.0.3,asynckivy,asyncgui,pyjnius, docutils,netifaces,filetype,requests_toolbelt,websockets,android-widgets, https://github.com/Fector101/android_notify/archive/main.zip
+requirements = python3,kivy,https://github.com/kivymd/KivyMD/archive/master.zip,python-osc,https://github.com/kivy/plyer/archive/master.zip,materialyoucolor>=3.0.3,asynckivy,asyncgui,pyjnius, docutils,netifaces,filetype,requests_toolbelt,websockets,android-widgets, https://github.com/Fector101/android_notify/archive/main.zip
 services = Wallpapercarousel:./android/services/wallpaper.py:foreground:foregroundServiceType=specialUse
 # Shorttask:./android/services/shorttask.py
 

--- a/buildozer.spec
+++ b/buildozer.spec
@@ -21,7 +21,7 @@ source.include_exts = py,png,jpg,kv,atlas,ttf,json,xml,wav
 source.exclude_dirs = bin, venv,lab, worked, __pycache__, .idea, dist, for-download,laner-linux, .filereader, wallpapers
 
 
-requirements = python3,kivy,https://github.com/kivymd/KivyMD/archive/master.zip,python-osc,https://github.com/kivy/plyer/archive/master.zip,materialyoucolor,asynckivy,asyncgui,pyjnius, docutils,netifaces,filetype,requests_toolbelt,websockets,android-widgets, https://github.com/Fector101/android_notify/archive/main.zip
+requirements = python3,kivy,https://github.com/kivymd/KivyMD/archive/master.zip,python-osc,https://github.com/kivy/plyer/archive/master.zip,materialyoucolor==3.0.3,asynckivy,asyncgui,pyjnius, docutils,netifaces,filetype,requests_toolbelt,websockets,android-widgets, https://github.com/Fector101/android_notify/archive/main.zip
 services = Wallpapercarousel:./android/services/wallpaper.py:foreground:foregroundServiceType=specialUse
 # Shorttask:./android/services/shorttask.py
 


### PR DESCRIPTION
- Buildozer kept going for the  old version of `materialyoucolor: 2.0.10` even when there was no pinning, i solved this by pinning.

- I also moved logs file to a public directory `Android/data/org.wally.waller/files`

